### PR TITLE
Update blank.yml

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     if: github.event.repository.owner.id == github.event.sender.id
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     
     steps:
     - name: Check Out


### PR DESCRIPTION
Ubuntu 18.04 runner is unsupported, so update to Ubuntu 20.04.
I have tested this change.The results show that it still works in the Ubuntu 20.04 environment.